### PR TITLE
Add wardrobe 2

### DIFF
--- a/Iocaine Applications/Iocaine 2/Iocaine2/Fisher_Form_1.cs
+++ b/Iocaine Applications/Iocaine 2/Iocaine2/Fisher_Form_1.cs
@@ -476,6 +476,7 @@ namespace Iocaine2
             // This is called after the process has changed and while the
             // background threads are still frozen.
             // If you need to do anything before resuming the IocaineThreads, do it here.
+            PlayerCache.Reset();
         }
         private void TOP_Init_Process_End()
         {

--- a/Iocaine Applications/Iocaine 2/Iocaine2/Fisher_Form_1_PL.cs
+++ b/Iocaine Applications/Iocaine 2/Iocaine2/Fisher_Form_1_PL.cs
@@ -2483,57 +2483,65 @@ namespace Iocaine2
             while (true)
             {
                 IocaineFunctions.delay((uint)Statics.Settings.PowerLevel.PlCharActivePollFrequency);
-                if (PL_PauseCheckActiveThread || (PL_CharacterList.Count == 0))
+                try
                 {
-                    continue;
-                }
-                else
-                {
-                    LoggingFunctions.Debug("PL_CheckPlayerActivityThreadRun: =====================================================", LoggingFunctions.DBG_SCOPE.BACKGROUND);
-                    foreach (PLCharacter chr in PL_CharacterList)
+                    if (PL_PauseCheckActiveThread || (PL_CharacterList.Count == 0))
                     {
-                        LoggingFunctions.Debug("PL_CheckPlayerActivityThreadRun: Checking player " + chr.Name + ".", LoggingFunctions.DBG_SCOPE.BACKGROUND);
-                        int charRow = 0;
-                        foreach (DataGridViewRow row in CharacterGrid.Rows)
-                        {
-                            LoggingFunctions.Debug("PL_CheckPlayerActivityThreadRun: Comparing with grid row #" + row.Index + " w/ value " + (String)row.Cells[(int)PL_CHAR_GRID_COL.NAME].Value + ".", LoggingFunctions.DBG_SCOPE.BACKGROUND);
-                            if ((String)row.Cells[(int)PL_CHAR_GRID_COL.NAME].Value == chr.Name)
-                            {
-                                LoggingFunctions.Debug("PL_CheckPlayerActivityThreadRun: Compare matched. Cell value: " + ((String)row.Cells[(int)PL_CHAR_GRID_COL.NAME].Value) + " chr.Name: " + chr.Name + ".", LoggingFunctions.DBG_SCOPE.BACKGROUND);
-                                charRow = row.Index;
-                                LoggingFunctions.Debug("PL_CheckPlayerActivityThreadRun: row.Index is " + row.Index + ".", LoggingFunctions.DBG_SCOPE.BACKGROUND);
-                                break;
-                            }
-                        }
-                        LoggingFunctions.Debug("PL_CheckPlayerActivityThreadRun: Character: " + chr.Name + " returns checkActive: " + chr.Check_Active().ToString() + ".", LoggingFunctions.DBG_SCOPE.BACKGROUND);
-                        bool chrActive = chr.Check_Active();
-                        bool inRange = false;
-                        if (chr.Name != PlayerCache.Vitals.Name)
-                        {
-                            inRange = chr.Distance <= 46;
-                        }
-                        else
-                        {
-                            inRange = true;
-                        }
-                        if (!chrActive)
-                        {
-                            chrActive = chr.Update_Pointer();
-                        }
-                        if (chrActive && inRange)
-                        {
-                            CharacterGrid[(int)PL_CHAR_GRID_COL.ACT, charRow].Value = Resources.GreenCheck;
-                        }
-                        else if(chrActive && !inRange)
-                        {
-                            CharacterGrid[(int)PL_CHAR_GRID_COL.ACT, charRow].Value = Resources.BlueArrow;
-                        }
-                        else
-                        {
-                            CharacterGrid[(int)PL_CHAR_GRID_COL.ACT, charRow].Value = Resources.RedX;
-                        }
-                        LoggingFunctions.Debug("PL_CheckPlayerActivityThreadRun: Character " + chr.Name + " on row " + charRow.ToString() + " is now " + (chr.Active ? "active" : "NOT active") + " and " + (inRange ? "" : "not ") + "in range.", LoggingFunctions.DBG_SCOPE.BACKGROUND);
+                        continue;
                     }
+                    else
+                    {
+                        LoggingFunctions.Debug("PL_CheckPlayerActivityThreadRun: =====================================================", LoggingFunctions.DBG_SCOPE.BACKGROUND);
+                        foreach (PLCharacter chr in PL_CharacterList)
+                        {
+                            LoggingFunctions.Debug("PL_CheckPlayerActivityThreadRun: Checking player " + chr.Name + ".", LoggingFunctions.DBG_SCOPE.BACKGROUND);
+                            int charRow = 0;
+                            foreach (DataGridViewRow row in CharacterGrid.Rows)
+                            {
+                                LoggingFunctions.Debug("PL_CheckPlayerActivityThreadRun: Comparing with grid row #" + row.Index + " w/ value " + (String)row.Cells[(int)PL_CHAR_GRID_COL.NAME].Value + ".", LoggingFunctions.DBG_SCOPE.BACKGROUND);
+                                if ((String)row.Cells[(int)PL_CHAR_GRID_COL.NAME].Value == chr.Name)
+                                {
+                                    LoggingFunctions.Debug("PL_CheckPlayerActivityThreadRun: Compare matched. Cell value: " + ((String)row.Cells[(int)PL_CHAR_GRID_COL.NAME].Value) + " chr.Name: " + chr.Name + ".", LoggingFunctions.DBG_SCOPE.BACKGROUND);
+                                    charRow = row.Index;
+                                    LoggingFunctions.Debug("PL_CheckPlayerActivityThreadRun: row.Index is " + row.Index + ".", LoggingFunctions.DBG_SCOPE.BACKGROUND);
+                                    break;
+                                }
+                            }
+                            LoggingFunctions.Debug("PL_CheckPlayerActivityThreadRun: Character: " + chr.Name + " returns checkActive: " + chr.Check_Active().ToString() + ".", LoggingFunctions.DBG_SCOPE.BACKGROUND);
+                            bool chrActive = chr.Check_Active();
+                            bool inRange = false;
+                            if (chr.Name != PlayerCache.Vitals.Name)
+                            {
+                                inRange = chr.Distance <= 46;
+                            }
+                            else
+                            {
+                                inRange = true;
+                            }
+                            if (!chrActive)
+                            {
+                                chrActive = chr.Update_Pointer();
+                            }
+                            if (chrActive && inRange)
+                            {
+                                CharacterGrid[(int)PL_CHAR_GRID_COL.ACT, charRow].Value = Resources.GreenCheck;
+                            }
+                            else if (chrActive && !inRange)
+                            {
+                                CharacterGrid[(int)PL_CHAR_GRID_COL.ACT, charRow].Value = Resources.BlueArrow;
+                            }
+                            else
+                            {
+                                CharacterGrid[(int)PL_CHAR_GRID_COL.ACT, charRow].Value = Resources.RedX;
+                            }
+                            LoggingFunctions.Debug("PL_CheckPlayerActivityThreadRun: Character " + chr.Name + " on row " + charRow.ToString() + " is now " + (chr.Active ? "active" : "NOT active") + " and " + (inRange ? "" : "not ") + "in range.", LoggingFunctions.DBG_SCOPE.BACKGROUND);
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    LoggingFunctions.Error(e.ToString());
+                    continue;
                 }
             }
         }

--- a/Iocaine IP/Data Structures/PlayerCache.cs
+++ b/Iocaine IP/Data Structures/PlayerCache.cs
@@ -28,6 +28,13 @@ namespace Iocaine2
     /// </summary>
     public static partial class PlayerCache
     {
+        public static void Reset()
+        {
+            Vitals.Reset();
+            Equipment.Reset();
+            Skills.Reset();
+            Environment.Reset();
+        }
         public static class Vitals
         {
             #region Private Members
@@ -94,6 +101,16 @@ namespace Iocaine2
                 }
             }
             #endregion Public Properties
+            #region Public Methods
+            public static void Reset()
+            {
+                name = "";
+                mainJob = 0;
+                mainJobLvl = 1;
+                subJob = 0;
+                subJobLvl = 0;
+            }
+            #endregion Public Methods
         }
         public static class Equipment
         {
@@ -161,6 +178,16 @@ namespace Iocaine2
                 }
             }
             #endregion Public Properties
+            #region Public Methods
+            public static void Reset()
+            {
+                main = 0;
+                sub = 0;
+                range = 0;
+                ammo = 0;
+                ammoQuan = 0;
+        }
+            #endregion Public Methods
         }
         public static class Skills
         {
@@ -192,6 +219,13 @@ namespace Iocaine2
                 }
             }
             #endregion Public Properties
+            #region Public Methods
+            public static void Reset()
+            {
+                combatSkillType = 0;
+                combatSkillCurrentLvl = 0;
+            }
+            #endregion Public Methods
         }
         public static class Environment
         {
@@ -319,6 +353,21 @@ namespace Iocaine2
                 }
             }
             #endregion Public Properties
+            #region Public Methods
+            public static void Reset()
+            {
+                serverId = 0;
+                serverName = "";
+                zoneId = 0;
+                areaId = 0;
+                zoneAlias = 0;
+                zoneName = "";
+                areaName = "";
+                inMogHouse = false;
+                weatherId = 0;
+                weatherName = "";
+        }
+            #endregion Public Methods
         }
     }
 }

--- a/Iocaine IP/Memory Functions/ChangeMonitor.cs
+++ b/Iocaine IP/Memory Functions/ChangeMonitor.cs
@@ -856,42 +856,6 @@ namespace Iocaine2
             return localChr;
         }
         #endregion Utility Functions
-        #region Monitor Status
-        //public static MONITOR_STATE State
-        //{
-        //    get
-        //    {
-        //        return state;
-        //    }
-        //}
-        //private static bool checkStatus()
-        //{
-        //    switch(state)
-        //    {
-        //        case MONITOR_STATE.RUNNING:
-        //            return true;
-        //        case MONITOR_STATE.STOPPED:
-        //            return false;
-        //        case MONITOR_STATE.PAUSED_PROG:
-        //        case MONITOR_STATE.PAUSED_USER:
-        //            while(state != MONITOR_STATE.RUNNING)
-        //            {
-        //                if(state == MONITOR_STATE.STOPPED)
-        //                {
-        //                    return false;
-        //                }
-        //                if(mainProc == null)
-        //                {
-        //                    return false;
-        //                }
-        //                IocaineFunctions.delay(1000);
-        //            }
-        //            return true;
-        //        default:
-        //            return false;
-        //    }
-        //}
-        #endregion Monitor Status
         #region Monitor
         private static void runMonitor()
         {


### PR DESCRIPTION
Added a Player Cache data reset while the Thread Manager is frozen during a process change.  This will force all of the normal Change Monitor events to pop when changing to a new character, even if the new character has some matching data to the previous character.
